### PR TITLE
Add cylinder_inertial xacro

### DIFF
--- a/abb_resources/urdf/cylinder_inertial.xacro
+++ b/abb_resources/urdf/cylinder_inertial.xacro
@@ -1,0 +1,21 @@
+<?xml version="1.0"?>
+<robot xmlns:xacro="http://ros.org/wiki/xacro">
+
+<!--
+  Macro taken from https://github.com/ros-industrial/universal_robot
+  Original Author: Kelsey Hawkins
+  Contributers: Jimmy Da Silva, Ajit Krisshna N L, Muhammad Asif Rana
+-->
+
+  <xacro:macro name="cylinder_inertial" params="radius length mass *origin">
+    <inertial>
+      <mass value="${mass}" />
+      <xacro:insert_block name="origin" />
+      <inertia ixx="${0.0833333 * mass * (3 * radius * radius + length * length)}" ixy="0.0" ixz="0.0"
+        iyy="${0.0833333 * mass * (3 * radius * radius + length * length)}" iyz="0.0"
+        izz="${0.5 * mass * radius * radius}" />
+    </inertial>
+  </xacro:macro>
+
+
+</robot>


### PR DESCRIPTION
Add the cylinder inertial xacro to abb_resources as recommended in [this comment](https://github.com/ros-industrial/abb_experimental/pull/98#issuecomment-386326227).